### PR TITLE
Allow nullish objects in schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export function schema<T>(schema: SchemaType<T>): Predicate<T> {
   return function (value: unknown): value is T {
     if (isObject(value)) {
       for (let k in schema) {
-        if (!value[k]) return false;
+        if (!value.hasOwnProperty(k)) return false;
         if (!schema[k](value[k])) return false;
       }
       return true;


### PR DESCRIPTION
Use `hasOwnProperty` to check for property presence in `schema`

Hi, thanks for the great library. I've found a small bug, here's a reproduction and a PR.

```
interface MyType = {
  value: string
}

const myObject: MyType = {
  value: ""
}

console.log(schema<MyType>(myObject)); // false
```

This is because the empty string is nullish, and when the `!value[k]` check on line 87 runs, it returns false because while the value exists, it's nullish. I think what you actually wanted to check here was whether the value exists - and then use the subsequent check to validate the type.

Hope this helps, thanks!